### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,50 +1,44 @@
 {
 	"name": "grunt-superglue",
 	"description": "Multistep file concatenation.",
-
 	"version": "0.1.0",
-	
 	"homepage": "https://github.com/chkt/grunt-superglue",
 	"author": "Christoph Kettelhoit",
-	
 	"repository": {
 		"type": "git",
 		"url": "git://github.com/chkt/grunt-superglue.git"
 	},
-	
 	"bugs": {
 		"url": "https://github.com/chkt/grunt-superglue/issues"
 	},
-	
-	"licenses": [{
-		"type" : "MIT",
-		"url"  : "https://github.com/gruntjs/grunt-contrib-concat/blob/master/LICENSE"
-	}],
-
-	"engines" : {
-		"node" : ">=0.8.0"
+	"licenses": [
+		{
+			"type": "MIT",
+			"url": "https://github.com/gruntjs/grunt-contrib-concat/blob/master/LICENSE"
+		}
+	],
+	"engines": {
+		"node": ">=0.8.0"
 	},
 	"scripts": {
 		"test": "grunt test"
 	},
-	
-	"dependencies" : {
-		"chalk" : "~0.4.0"
+	"dependencies": {
+		"chalk": "~0.4.0"
 	},
-	"devDependencies" : {
-		"grunt-contrib-jshint"   : "~0.10.0",
-		"grunt-contrib-nodeunit" : "~0.3.0",
-		"grunt"                  : "~0.4.0"
+	"devDependencies": {
+		"grunt-contrib-jshint": "~0.10.0",
+		"grunt-contrib-nodeunit": "~0.3.0",
+		"grunt": "~0.4.0"
 	},
-	"peerDependencies" : {
-		"grunt" : "~0.4.0"
+	"peerDependencies": {
+		"grunt": ">=0.4.0"
 	},
-	
 	"keywords": [
 		"gruntplugin"
 	],
-	"files" : [
+	"files": [
 		"tasks",
 		"LICENSE"
-	]	
+	]
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
